### PR TITLE
rm environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,4 @@ services:
     ports:
       - 8080:8080
       - 9394:9394
-    environment:
-      - RUST_BACKTRACE=1
-      - RUST_LOG=trace
+


### PR DESCRIPTION
删除用于 RUST 调试的环境变量，避免调试日志持续增长占满硬盘空间